### PR TITLE
Changed Afghanistan Official Name

### DIFF
--- a/src/dataset/iso3166-1.json
+++ b/src/dataset/iso3166-1.json
@@ -11,7 +11,7 @@
       "alpha_3": "AFG",
       "name": "Afghanistan",
       "numeric": "004",
-      "official_name": "Islamic Republic of Afghanistan"
+      "official_name": "Islamic Emirate of Afghanistan"
     },
     {
       "alpha_2": "AO",


### PR DESCRIPTION
Due to the change in government the entity which has the most power over the country officially titles itself as the "Islamic Emirate of Afghanistan".

This is not meant to be a show of support of any side in the ongoing conflict(s) in the country or region. However this is the entity that makes up what can best be described as the current Afghan government.