### PR TITLE
MacOS arm64 binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,5 +16,7 @@ npm run compile
 
 ./node_modules/.bin/pkg ./package.json --targets node14-macos-x64 --output bin/geofeed-finder-macos-x64 --loglevel=error
 
+./node_modules/.bin/pkg ./package.json --targets node14-macos-arm64 --output bin/geofeed-finder-macos-arm64 --loglevel=error
+
 echo "--> Geofeed finder compiled in bin/"
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
       "assets": [
         "bin/geofeed-finder-linux-x64",
         "bin/geofeed-finder-macos-x64",
+        "bin/geofeed-finder-macos-arm64",
         "bin/geofeed-finder-win-x64.exe"
       ]
     }


### PR DESCRIPTION
While I have been unable to test this, it would be desirable to add build and release for macOS arm64 binaries (new Apple M1 silicon). 
Thanks for the wonderful tool!