### PR TITLE
Add ARM64 binaries to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,13 @@ npm run compile
 
 ./node_modules/.bin/pkg ./package.json --targets node18-linux-x64 --output bin/geofeed-finder-linux-x64 --loglevel=error
 
+./node_modules/.bin/pkg ./package.json --targets node18-linux-arm64 --output bin/geofeed-finder-linux-arm64 --loglevel=error
+
 ./node_modules/.bin/pkg ./package.json --targets node18-macos-x64 --output bin/geofeed-finder-macos-x64 --loglevel=error
+
+# The pkg tool considers macos-arm64 to be an experimental target (https://github.com/vercel/pkg). 
+# Pkg uses ad-hoc certification to sign the MacOS binary. Use your own certificate or skip entirely using --no-signature  
+./node_modules/.bin/pkg ./package.json --targets node18-macos-arm64 --output bin/geofeed-finder-macos-arm64 --loglevel=error
 
 echo "--> Geofeed finder compiled in bin/"
 

--- a/build.sh
+++ b/build.sh
@@ -18,9 +18,14 @@ npm run compile
 
 ./node_modules/.bin/pkg ./package.json --targets node18-macos-x64 --output bin/geofeed-finder-macos-x64 --loglevel=error
 
-# The pkg tool considers macos-arm64 to be an experimental target (https://github.com/vercel/pkg). 
-# Pkg uses ad-hoc certification to sign the MacOS binary. Use your own certificate or skip entirely using --no-signature  
-./node_modules/.bin/pkg ./package.json --targets node18-macos-arm64 --output bin/geofeed-finder-macos-arm64 --loglevel=error
+# The pkg tool considers macos-arm64 to be an experimental target (see https://github.com/vercel/pkg). 
+# Due to the mandatory code signing requirement, before the executable is distributed to end users, it must be signed.
+# Otherwise, it will be immediately killed by kernel on launch.
+# An ad-hoc signature is sufficient.
+# To do that, run pkg on a Mac, or transfer the executable to a Mac
+# and run "codesign --sign - <executable>"
+# or (if you use Linux) install "ldid" utility to PATH and then run pkg again 
+# ./node_modules/.bin/pkg ./package.json --targets node18-macos-arm64 --output bin/geofeed-finder-macos-arm64 --loglevel=error
 
 echo "--> Geofeed finder compiled in bin/"
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "babel": "./node_modules/.bin/babel",
     "build": "./build.sh",
-    "compile": "rm -rf dist/ && babel src -d dist && cp -R src/dataset/ dist/dataset/",
+    "compile": "rm -rf dist/ && babel src -d dist",
     "release": "dotenv release-it",
     "serve": "babel-node src/index.js",
     "inspect": "node --inspect --require @babel/register index.js",


### PR DESCRIPTION
Linux on ARM64 is primary request here as both Azure and AWS provide ARM64 servers. 
MacOS on ARM64 is documented but commented out for now. Feel free to uncomment that line if it works on your build machine. 
Thank you! :)