### PR TITLE
Attempt to fixup Github URLs

### DIFF
--- a/src/finder.js
+++ b/src/finder.js
@@ -149,6 +149,7 @@ export default class Finder {
             }
 
         } else {
+            file = this.maybeFixupGithubGeofeedUrl(file);
             this.logEntry(file, false);
             return axios({
                 url: file,
@@ -301,6 +302,27 @@ export default class Finder {
 
     matchGeofeedFile = (remark) => {
         return remark.match(/\bhttps?:\/\/\S+/gi) || [];
+    };
+
+    maybeFixupGithubGeofeedUrl = (urlString) => {
+        const { URL } = require('url');
+
+        try {
+            let parsedUrl = new URL(urlString);
+
+            let pathParts = parsedUrl.pathname.split('/');
+
+            if (parsedUrl.hostname === 'github.com' && pathParts.length > 3 && pathParts[3] === 'blob') {
+                parsedUrl.hostname = 'raw.githubusercontent.com';
+                pathParts.splice(3, 1); // Remove the 3rd part of the path
+                parsedUrl.pathname = pathParts.join('/');
+                console.log(`Fixed up bad Github url`);
+            }
+
+            return parsedUrl.toString();
+        } catch(error) {
+            return urlString;
+        }
     };
 
     translateObject = (object) => {


### PR DESCRIPTION
There are currently 39 geofeeds that are hosted on Github, but have the URL incorrectly set on their prefixes. This attempts to fixup these URLs so that those prefixes can be ingested. While the ideal solution would be for network owners to fix this themselves, this feels like a fairly easy fix that covers multiple network owners.