### PR TITLE
Support GitHub CDN URL's

### DIFF
--- a/src/finder.js
+++ b/src/finder.js
@@ -162,7 +162,7 @@ export default class Finder {
                 .then(response => {
                     const data = response.data;
                     if (Util.checkHtmlContent(data)) {
-                        const message = `Error: ${file} is not CSV but HTML, stop with this nonsense!`;
+                        const message = `Error: ${url} is not CSV but HTML, stop with this nonsense!`;
                         this.logger.log(message);
                         console.log(message);
                     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
-import Finder from "./finder"
 import fs from "fs";
 import yargs from 'yargs';
+import Finder from "./finder";
+import Util from "./util";
 
 const toGeofeed = (geofeedsObjects) => geofeedsObjects.join("\n");
 
@@ -16,7 +17,7 @@ const logger = new FileLogger({
     compressOnRotation: false,
     label: "geofeed-finder",
     useUTC: true,
-    format: ({data, timestamp}) => `${timestamp} ${data}`
+    format: ({ data, timestamp }) => `${timestamp} ${data}`
 });
 
 
@@ -129,7 +130,7 @@ new Finder(options)
     .getGeofeeds()
     .then(data => {
         if (!!options.test) {
-            if (/<a|<div|<span|<style|<link/gi.test(data)) {
+            if (Util.checkHtmlContent(data)) {
                 console.log(`Error: is not CSV but HTML, stop with this nonsense!`);
             } else {
                 console.log(toGeofeed(data));

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,29 @@
+class Util {
+
+    static testGeofeedRemark(remark) {
+        return /^Geofeed:?\s+https?:\/\/\S+/gi.test(remark);
+    }
+
+    static testGeofeedRemarkStrict(remark) {
+        return /\sGeofeed https?:\/\/\S+/g.test(remark);
+    }
+
+    static matchGeofeedFile(remark) {
+        return remark.match(/\bhttps?:\/\/\S+/gi) || [];
+    }
+
+    static checkHtmlContent(content) {
+        return /<a|<div|<span|<style|<link/gi.test(content)
+    }
+
+    static getParsedGithubUrl(file) {
+        let parsedUrl;
+        (file.startsWith('https://github.com/') ||
+            file.startsWith('http://github.com/') ||
+            file.startsWith('github.com/')) ?
+            parsedUrl = file.replace('/blob/', '/raw/') : parsedUrl = file;
+        return parsedUrl;
+    }
+}
+
+export default Util;

--- a/src/util.js
+++ b/src/util.js
@@ -17,12 +17,11 @@ class Util {
     }
 
     static getParsedGithubUrl(file) {
-        let parsedUrl;
-        (file.startsWith('https://github.com/') ||
-            file.startsWith('http://github.com/') ||
-            file.startsWith('github.com/')) ?
-            parsedUrl = file.replace('/blob/', '/raw/') : parsedUrl = file;
-        return parsedUrl;
+        if (file.startsWith('https://github.com/') || file.startsWith('github.com/')) {
+            return file.replace('github.com', 'raw.githubusercontent.com').replace('/blob', '');
+        }
+
+        return file;
     }
 }
 


### PR DESCRIPTION
Hi @massimocandela,

Great work on this project!

I hope you don't mind this pull request. I have added support for parsing GitHub URLs in the blob format, which allows for direct downloading from the GitHub CDN. Additionally, I have moved all regex operations to the `Util` class for coherence.

This also closes https://github.com/massimocandela/geofeed-finder/issues/36

![Screenshot 2024-06-03 221938](https://github.com/massimocandela/geofeed-finder/assets/5440296/e98f36c6-98ee-41aa-9d18-35abfe46bbdf)

Best regards,
João Duarte