### PR TITLE
Two useful flags: -x to disable processing (download only), -f for custom geofeed list

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The application accepts the following parameters:
 | -r        | Remove invalid subdivisions but keep the rest of the geofeed if valid.                                               | 
 | -z        | Include Zip codes. Not recommended. Zip codes are deprecated in geofeed and by default are excluded from the output. | 
 | -d        | Download timeout. Interrupt downloading a geofeed file after seconds. Default: 10 seconds.                           |
+| -f        | Path to a file with additional geofeed URLs (one per line).                                                          |
+| -x        | Download geofeed files but skip processing and validation.                                                           |
 | -p        | Do not fetch arin sub allocations. You will save considerable time but have a potentially partial output.            |
 | -q        | Detect ARIN's sub allocations locally instead of downloading a dump file.                                            |
 | -a        | A comma-separated list of address families. Default: `4,6`.                                                          |
@@ -128,7 +130,9 @@ const options = {
     skipSuballocations: true | false, // Skip fetching ARIN sub allocations
     test: "ip/prefix", // Test specific ip/prefix using RDAP
     output: "result.csv", // Output file (default: "result.csv")
-    downloadTimeout: 5 // Interrupt downloading a geofeed file after seconds (default: 10)
+    downloadTimeout: 5, // Interrupt downloading a geofeed file after seconds (default: 10)
+    customFeedsFile: "/path/to/custom-feeds.txt", // Additional geofeed URLs (one per line)
+    disableProcessing: true | false // Download geofeed files but skip processing and validation
 };
 
 new GeofeedFinder(options) // The options dict is optional, you can just do new GeofeedFinder()
@@ -138,6 +142,5 @@ new GeofeedFinder(options) // The options dict is optional, you can just do new 
         // An array of objects { prefix, country, region, city }
     });
 ```
-
 
 

--- a/src/csvParser.js
+++ b/src/csvParser.js
@@ -16,7 +16,8 @@ export default class CsvParser {
 
                 if (!!prefix) {
                     try {
-                        const geofeed = new Geofeed(inetnum, prefix, country, region, city, zip);
+                        const baseInetnum = inetnum || prefix;
+                        const geofeed = new Geofeed(baseInetnum, prefix, country, region, city, zip);
 
                         out.push(geofeed);
                     } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,14 @@ const params = yargs
             .nargs("d", 1)
             .describe("d", "Interrupt downloading a geofeed file after seconds")
 
+            .alias("f", "custom-feeds")
+            .nargs("f", 1)
+            .describe("f", "Path to a file with additional geofeed URLs (one per line)")
+
+            .alias("x", "disable-processing")
+            .nargs("x", 0)
+            .describe("x", "Download geofeed files but skip processing and validation")
+
             .alias("i", "include")
             .nargs("i", 1)
             .default("i", "ripe,apnic,lacnic,afrinic,arin")
@@ -118,6 +126,8 @@ const options = {
     keepNonIso: !!params.k,
     keepInvalidSubdivisions: !!params.u,
     removeInvalidSubdivisions: !!params.r,
+    disableProcessing: !!params.x,
+    customFeedsFile: params.f || null,
     include: (params.i ?? "ripe,apnic,lacnic,afrinic,arin").split(","),
     output: params.o || "result.csv",
     test: params.t || null,
@@ -152,7 +162,9 @@ new Finder(options)
                     out.end();
 
                     out.on("finish", () => {
-                        console.log(`Done! See ${options.output}`);
+                        if (!options.disableProcessing) {
+                            console.log(`Done! See ${options.output}`);
+                        }
                         resolve();
                     });
 


### PR DESCRIPTION
- Add -x/--disable-processing to download geofeed files without validation/processing.
- Add -f/--custom-feeds to include extra geofeed URLs from a file.
- Improve CSV parsing by falling back to prefix when inetnum is missing.

